### PR TITLE
Updating defmodel bbox parameters

### DIFF
--- a/data/deformation_model.schema.json
+++ b/data/deformation_model.schema.json
@@ -306,19 +306,14 @@
           ]
         },
         "parameters": {
-          "type": "array",
-          "minItems": 1,
-          "maxItems": 1,
-          "items": {
-            "type": "object",
-            "properties": {
-              "bbox": {
-                "type": "array",
-                "minItems": 4,
-                "maxItems": 4,
-                "items": {
-                  "type": "number"
-                }
+          "type": "object",
+          "properties": {
+            "bbox": {
+              "type": "array",
+              "minItems": 4,
+              "maxItems": 4,
+              "items": {
+                "type": "number"
               }
             }
           }

--- a/data/tests/simple_model_degree_3d.json
+++ b/data/tests/simple_model_degree_3d.json
@@ -8,41 +8,47 @@
   "horizontal_offset_method": "addition",
   "vertical_offset_unit": "metre",
   "extent": {
-    "type": "bbox", 
-    "parameters": [
-      {
-        "bbox": [-180,-90,180,90]
-      }
-    ]
-  }, 
+    "type": "bbox",
+    "parameters": {
+      "bbox": [
+        -180,
+        -90,
+        180,
+        90
+      ]
+    }
+  },
   "time_extent": {
-    "first": "1900-01-01T00:00:00Z", 
+    "first": "1900-01-01T00:00:00Z",
     "last": "2050-01-01T00:00:00Z"
   },
   "components": [
     {
-        "description": "test", 
-        "displacement_type": "3d", 
-        "uncertainty_type": "none", 
-        "extent": {
-            "type": "bbox", 
-            "parameters": [
-            {
-                "bbox": [-180,-90,180,90]
-            }
-            ]
-        }, 
-        "spatial_model": {
-            "type": "GeoTIFF", 
-            "interpolation_method": "bilinear", 
-            "filename": "tests/simple_model_degree_3d_grid.tif"
-        }, 
-        "time_function": {
-            "type": "step", 
-            "parameters": {
-                "step_epoch": "1900-01-01T00:00:00Z"
-            }
+      "description": "test",
+      "displacement_type": "3d",
+      "uncertainty_type": "none",
+      "extent": {
+        "type": "bbox",
+        "parameters": {
+          "bbox": [
+            -180,
+            -90,
+            180,
+            90
+          ]
         }
+      },
+      "spatial_model": {
+        "type": "GeoTIFF",
+        "interpolation_method": "bilinear",
+        "filename": "tests/simple_model_degree_3d_grid.tif"
+      },
+      "time_function": {
+        "type": "step",
+        "parameters": {
+          "step_epoch": "1900-01-01T00:00:00Z"
         }
+      }
+    }
   ]
 }

--- a/data/tests/simple_model_degree_horizontal.json
+++ b/data/tests/simple_model_degree_horizontal.json
@@ -7,41 +7,47 @@
   "horizontal_offset_unit": "degree",
   "horizontal_offset_method": "addition",
   "extent": {
-    "type": "bbox", 
-    "parameters": [
-      {
-        "bbox": [-180,-90,180,90]
-      }
-    ]
-  }, 
+    "type": "bbox",
+    "parameters": {
+      "bbox": [
+        -180,
+        -90,
+        180,
+        90
+      ]
+    }
+  },
   "time_extent": {
-    "first": "1900-01-01T00:00:00Z", 
+    "first": "1900-01-01T00:00:00Z",
     "last": "2050-01-01T00:00:00Z"
   },
   "components": [
     {
-        "description": "test", 
-        "displacement_type": "horizontal", 
-        "uncertainty_type": "none", 
-        "extent": {
-            "type": "bbox", 
-            "parameters": [
-            {
-                "bbox": [-180,-90,180,90]
-            }
-            ]
-        }, 
-        "spatial_model": {
-            "type": "GeoTIFF", 
-            "interpolation_method": "bilinear", 
-            "filename": "tests/simple_model_degree_3d_grid.tif"
-        }, 
-        "time_function": {
-            "type": "step", 
-            "parameters": {
-                "step_epoch": "1900-01-01T00:00:00Z"
-            }
+      "description": "test",
+      "displacement_type": "horizontal",
+      "uncertainty_type": "none",
+      "extent": {
+        "type": "bbox",
+        "parameters": {
+          "bbox": [
+            -180,
+            -90,
+            180,
+            90
+          ]
         }
+      },
+      "spatial_model": {
+        "type": "GeoTIFF",
+        "interpolation_method": "bilinear",
+        "filename": "tests/simple_model_degree_3d_grid.tif"
+      },
+      "time_function": {
+        "type": "step",
+        "parameters": {
+          "step_epoch": "1900-01-01T00:00:00Z"
         }
+      }
+    }
   ]
 }

--- a/data/tests/simple_model_metre_3d.json
+++ b/data/tests/simple_model_metre_3d.json
@@ -8,41 +8,47 @@
   "horizontal_offset_method": "addition",
   "vertical_offset_unit": "metre",
   "extent": {
-    "type": "bbox", 
-    "parameters": [
-      {
-        "bbox": [-180,-90,180,90]
-      }
-    ]
-  }, 
+    "type": "bbox",
+    "parameters": {
+      "bbox": [
+        -180,
+        -90,
+        180,
+        90
+      ]
+    }
+  },
   "time_extent": {
-    "first": "1900-01-01T00:00:00Z", 
+    "first": "1900-01-01T00:00:00Z",
     "last": "2050-01-01T00:00:00Z"
   },
   "components": [
     {
-        "description": "test", 
-        "displacement_type": "3d", 
-        "uncertainty_type": "none", 
-        "extent": {
-            "type": "bbox", 
-            "parameters": [
-            {
-                "bbox": [-180,-90,180,90]
-            }
-            ]
-        }, 
-        "spatial_model": {
-            "type": "GeoTIFF", 
-            "interpolation_method": "bilinear", 
-            "filename": "tests/simple_model_metre_3d_grid.tif"
-        }, 
-        "time_function": {
-            "type": "step", 
-            "parameters": {
-                "step_epoch": "1900-01-01T00:00:00Z"
-            }
+      "description": "test",
+      "displacement_type": "3d",
+      "uncertainty_type": "none",
+      "extent": {
+        "type": "bbox",
+        "parameters": {
+          "bbox": [
+            -180,
+            -90,
+            180,
+            90
+          ]
         }
+      },
+      "spatial_model": {
+        "type": "GeoTIFF",
+        "interpolation_method": "bilinear",
+        "filename": "tests/simple_model_metre_3d_grid.tif"
+      },
+      "time_function": {
+        "type": "step",
+        "parameters": {
+          "step_epoch": "1900-01-01T00:00:00Z"
         }
+      }
+    }
   ]
 }

--- a/data/tests/simple_model_metre_3d_geocentric.json
+++ b/data/tests/simple_model_metre_3d_geocentric.json
@@ -8,41 +8,47 @@
   "horizontal_offset_method": "geocentric",
   "vertical_offset_unit": "metre",
   "extent": {
-    "type": "bbox", 
-    "parameters": [
-      {
-        "bbox": [-180,-90,180,90]
-      }
-    ]
-  }, 
+    "type": "bbox",
+    "parameters": {
+      "bbox": [
+        -180,
+        -90,
+        180,
+        90
+      ]
+    }
+  },
   "time_extent": {
-    "first": "1900-01-01T00:00:00Z", 
+    "first": "1900-01-01T00:00:00Z",
     "last": "2050-01-01T00:00:00Z"
   },
   "components": [
     {
-        "description": "test", 
-        "displacement_type": "3d", 
-        "uncertainty_type": "none", 
-        "extent": {
-            "type": "bbox", 
-            "parameters": [
-            {
-                "bbox": [-180,-90,180,90]
-            }
-            ]
-        }, 
-        "spatial_model": {
-            "type": "GeoTIFF", 
-            "interpolation_method": "bilinear", 
-            "filename": "tests/simple_model_metre_3d_grid.tif"
-        }, 
-        "time_function": {
-            "type": "step", 
-            "parameters": {
-                "step_epoch": "1900-01-01T00:00:00Z"
-            }
+      "description": "test",
+      "displacement_type": "3d",
+      "uncertainty_type": "none",
+      "extent": {
+        "type": "bbox",
+        "parameters": {
+          "bbox": [
+            -180,
+            -90,
+            180,
+            90
+          ]
         }
+      },
+      "spatial_model": {
+        "type": "GeoTIFF",
+        "interpolation_method": "bilinear",
+        "filename": "tests/simple_model_metre_3d_grid.tif"
+      },
+      "time_function": {
+        "type": "step",
+        "parameters": {
+          "step_epoch": "1900-01-01T00:00:00Z"
         }
+      }
+    }
   ]
 }

--- a/data/tests/simple_model_metre_horizontal.json
+++ b/data/tests/simple_model_metre_horizontal.json
@@ -7,41 +7,47 @@
   "horizontal_offset_unit": "metre",
   "horizontal_offset_method": "addition",
   "extent": {
-    "type": "bbox", 
-    "parameters": [
-      {
-        "bbox": [-180,-90,180,90]
-      }
-    ]
-  }, 
+    "type": "bbox",
+    "parameters": {
+      "bbox": [
+        -180,
+        -90,
+        180,
+        90
+      ]
+    }
+  },
   "time_extent": {
-    "first": "1900-01-01T00:00:00Z", 
+    "first": "1900-01-01T00:00:00Z",
     "last": "2050-01-01T00:00:00Z"
   },
   "components": [
     {
-        "description": "test", 
-        "displacement_type": "horizontal", 
-        "uncertainty_type": "none", 
-        "extent": {
-            "type": "bbox", 
-            "parameters": [
-            {
-                "bbox": [-180,-90,180,90]
-            }
-            ]
-        }, 
-        "spatial_model": {
-            "type": "GeoTIFF", 
-            "interpolation_method": "bilinear", 
-            "filename": "tests/simple_model_metre_3d_grid.tif"
-        }, 
-        "time_function": {
-            "type": "step", 
-            "parameters": {
-                "step_epoch": "1900-01-01T00:00:00Z"
-            }
+      "description": "test",
+      "displacement_type": "horizontal",
+      "uncertainty_type": "none",
+      "extent": {
+        "type": "bbox",
+        "parameters": {
+          "bbox": [
+            -180,
+            -90,
+            180,
+            90
+          ]
         }
+      },
+      "spatial_model": {
+        "type": "GeoTIFF",
+        "interpolation_method": "bilinear",
+        "filename": "tests/simple_model_metre_3d_grid.tif"
+      },
+      "time_function": {
+        "type": "step",
+        "parameters": {
+          "step_epoch": "1900-01-01T00:00:00Z"
         }
+      }
+    }
   ]
 }

--- a/src/transformations/defmodel.hpp
+++ b/src/transformations/defmodel.hpp
@@ -1049,12 +1049,7 @@ SpatialExtent SpatialExtent::parse(const json &j) {
         throw ParsingException("unsupported type of extent");
     }
 
-    const json jParameters = getArrayMember(j, "parameters");
-    if (jParameters.size() != 1) {
-        throw ParsingException(
-            "Only one member support in extent.parameters[]");
-    }
-    const json jParameter = jParameters[0];
+    const json jParameter = getObjectMember(j, "parameters");
     const json jBbox = getArrayMember(jParameter, "bbox");
     if (jBbox.size() != 4) {
         throw ParsingException("bbox is not an array of 4 numeric elements");

--- a/test/unit/test_defmodel.cpp
+++ b/test/unit/test_defmodel.cpp
@@ -64,7 +64,7 @@ static json getMinValidContent() {
     j["definition_crs"] = "EPSG:4959";
     j["extent"]["type"] = "bbox";
     j["extent"]["parameters"] = {
-        {{"bbox", {modelMinX, modelMinY, modelMaxX, modelMaxY}}}};
+        {"bbox", {modelMinX, modelMinY, modelMaxX, modelMaxY}}};
     j["time_extent"]["first"] = "1900-01-01T00:00:00Z";
     j["time_extent"]["last"] = "2050-01-01T00:00:00Z";
     j["components"] = json::array();
@@ -113,7 +113,7 @@ static json getFullValidContent() {
         {"extent",
          {{"type", "bbox"},
           {"parameters",
-           {{{"bbox", {modelMinX, modelMinY, modelMaxX, modelMaxY}}}}}}},
+           {{"bbox", {modelMinX, modelMinY, modelMaxX, modelMaxY}}}}}},
         {"spatial_model",
          {
              {"type", "GeoTIFF"},
@@ -225,25 +225,25 @@ TEST(defmodel, basic) {
 
     {
         json jcopy(jMinValid);
-        jcopy["extent"]["parameters"][0].erase("bbox");
+        jcopy["extent"]["parameters"].erase("bbox");
         EXPECT_THROW(MasterFile::parse(jcopy.dump()), ParsingException);
     }
 
     {
         json jcopy(jMinValid);
-        jcopy["extent"]["parameters"][0]["bbox"] = "foo";
+        jcopy["extent"]["parameters"]["bbox"] = "foo";
         EXPECT_THROW(MasterFile::parse(jcopy.dump()), ParsingException);
     }
 
     {
         json jcopy(jMinValid);
-        jcopy["extent"]["parameters"][0]["bbox"] = {0, 1, 2};
+        jcopy["extent"]["parameters"]["bbox"] = {0, 1, 2};
         EXPECT_THROW(MasterFile::parse(jcopy.dump()), ParsingException);
     }
 
     {
         json jcopy(jMinValid);
-        jcopy["extent"]["parameters"][0]["bbox"] = {0, 1, 2, "foo"};
+        jcopy["extent"]["parameters"]["bbox"] = {0, 1, 2, "foo"};
         EXPECT_THROW(MasterFile::parse(jcopy.dump()), ParsingException);
     }
 
@@ -680,7 +680,7 @@ TEST(defmodel, evaluator_horizontal_unit_degree) {
          {"extent",
           {{"type", "bbox"},
            {"parameters",
-            {{{"bbox", {gridMinX, gridMinY, gridMaxX, gridMaxY}}}}}}},
+            {{"bbox", {gridMinX, gridMinY, gridMaxX, gridMaxY}}}}}},
          {"spatial_model",
           {
               {"type", "GeoTIFF"},
@@ -1042,9 +1042,9 @@ TEST(defmodel, evaluator_horizontal_unit_metre) {
          {"extent",
           {{"type", "bbox"},
            {"parameters",
-            {{{"bbox",
+            {{"bbox",
                {gridMinX - extraPointX * gridResX,
-                gridMinY - extraPointY * gridResY, gridMaxX, gridMaxY}}}}}}},
+                gridMinY - extraPointY * gridResY, gridMaxX, gridMaxY}}}}}},
          {"spatial_model",
           {
               {"type", "GeoTIFF"},


### PR DESCRIPTION
Removing the array from the extent bbox parameters to make these consistent with spatial model.  I think my original example JSON file in the format definition document had incorrectly placed these in an array.  This has been fixed in the document.  With this fix the header file can load the LINZ deformation model.