### PR TITLE
Adding "constant" time function

### DIFF
--- a/src/transformations/defmodel.hpp
+++ b/src/transformations/defmodel.hpp
@@ -210,7 +210,10 @@ class Component {
       protected:
         TimeFunction() = default;
     };
+    struct ConstantTimeFunction : public TimeFunction {
 
+        virtual double evaluateAt(double dt) const override;
+    };
     struct VelocityTimeFunction : public TimeFunction {
         /** Date/time at which the velocity function is zero. */
         Epoch referenceEpoch{};
@@ -1109,7 +1112,11 @@ Component Component::parse(const json &j) {
     const std::string timeFunctionType = getReqString(jTimeFunction, "type");
     const json jParameters = getObjectMember(jTimeFunction, "parameters");
 
-    if (timeFunctionType == "velocity") {
+    if (timeFunctionType == "constant") {
+        std::unique_ptr<ConstantTimeFunction> tf(new ConstantTimeFunction());
+        tf->type = timeFunctionType;
+        comp.mTimeFunction = std::move(tf);
+    } else if (timeFunctionType == "velocity") {
         std::unique_ptr<VelocityTimeFunction> tf(new VelocityTimeFunction());
         tf->type = timeFunctionType;
         tf->referenceEpoch =
@@ -1175,6 +1182,12 @@ Component Component::parse(const json &j) {
     }
 
     return comp;
+}
+
+// ---------------------------------------------------------------------------
+
+double Component::ConstantTimeFunction::evaluateAt(double) const {
+    return 1.0;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Another documentation failure on my part - I had started to add a missing time function which is the trivial "constant" function but never completed it.  This always has value 1.0, basically it is a simple grid shift.  For LINZ the type of situation we could use this is if we decide to upgrade the velocity model or shift the base epoch of the velocity model.  However Kristian also hinted at a user case of using this format to include the errors for offset grids.