### PR TITLE
Add Finnish geoid models to grid_alternatives.sql

### DIFF
--- a/data/CMakeLists.txt
+++ b/data/CMakeLists.txt
@@ -45,7 +45,7 @@ set(ALL_SQL_IN "${CMAKE_CURRENT_BINARY_DIR}/all.sql.in")
 set(PROJ_DB "${CMAKE_CURRENT_BINARY_DIR}/proj.db")
 include(sql_filelist.cmake)
 
-set(PROJ_DB_SQL_EXPECTED_MD5 "c2184d9fca631e88f21e4c0d8899d391")
+set(PROJ_DB_SQL_EXPECTED_MD5 "5cae0af56a2189692c8e1cf83fe7929e")
 
 add_custom_command(
   OUTPUT ${PROJ_DB}

--- a/data/sql/grid_alternatives.sql
+++ b/data/sql/grid_alternatives.sql
@@ -169,6 +169,9 @@ VALUES
 ('eur_nkg_nkgrf17vel.tif','eur_nkg_nkgrf17vel.tif',NULL,'GTiff','velocity_grid',0,NULL,'https://cdn.proj.org/eur_nkg_nkgrf17vel.tif',1,1,NULL),
 
 -- fi_nls - National Land Survey of Finland (MML)
+('fi_nls_fin2000.tif','fi_nls_fin2000.tif',NULL,'GTiff','geoid_like',0,NULL,'https://cdn.proj.org/fi_nls_fin2000.tif',1,1,NULL),
+('fi_nls_fin2005n00.tif','fi_nls_fin2005n00.tif',NULL,'GTiff','geoid_like',0,NULL,'https://cdn.proj.org/fi_nls_fin2005n00.tif',1,1,NULL),
+('fi_nls_fin2023n2000.tif','fi_nls_fin2023n2000.tif',NULL,'GTiff','geoid_like',0,NULL,'https://cdn.proj.org/fi_nls_fin2023n2000.tif',1,1,NULL),
 ('fi_nls_n43_n60.json','fi_nls_n43_n60.json',NULL,'JSON','tinshift',0,NULL,'https://cdn.proj.org/fi_nls_n43_n60.json',1,1,NULL),
 ('fi_nls_n60_n2000.json','fi_nls_n60_n2000.json',NULL,'JSON','tinshift',0,NULL,'https://cdn.proj.org/fi_nls_n60_n2000.json',1,1,NULL),
 ('fi_nls_ykj_etrs35fin.json','fi_nls_ykj_etrs35fin.json',NULL,'JSON','tinshift',0,NULL,'https://cdn.proj.org/fi_nls_ykj_etrs35fin.json',1,1,NULL),


### PR DESCRIPTION
The filenames are the same, but it is needed for PROJ to search them in cdn.proj.org

---

Once https://github.com/OSGeo/PROJ/pull/4353 is merged into master, I will change the target of the PR